### PR TITLE
Updated _androidstudio.md

### DIFF
--- a/src/docs/get-started/test-drive/_androidstudio.md
+++ b/src/docs/get-started/test-drive/_androidstudio.md
@@ -4,7 +4,7 @@
 
 {% include_relative _web-app.md  %}
 
- 1. Open the IDE and select **Start a new Flutter project**.
+ 1. Open the IDE and select **Create New Flutter Project**.
  1. Select **Flutter Application** as the project type. Then click **Next**.
  1. Verify the Flutter SDK path specifies the SDK’s location
     (select **Install SDK...** if the text field is blank).


### PR DESCRIPTION
In the **Create The App > Android Studio** section 
Before the change 1st point was: "Open the IDE and select **Start a new Flutter project.**"

While, in new android studio version it has changed to: "_Create New Flutter Project_"

This PR resolves #5547 issue.
